### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -6,7 +6,7 @@
   ],
   "tags": [ "config"],
   "description": "Refinements on use of configurations loaded with parsers such as found in Config::TOML",
-  "license": "The Artistic License 2.0",
+  "license": "Artistic-2.0",
   "name": "Config::DataLang::Refine",
   "perl": "6",
   "provides": {


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license