### PR TITLE
Make tests pass on rakudo 2018.05

### DIFF
--- a/t/100-refine-toml.t
+++ b/t/100-refine-toml.t
@@ -243,7 +243,7 @@ subtest {
   nok '--workdir=/tmp' ~~ any(@$o), 'app --workdir /tmp not in list';
   nok '-p' ~~ any(@$o), 'app -p not in list';
   nok '-q' ~~ any(@$o), 'app -q not in list';
-  ok '-pq' ~~ any(@$o), 'app -pq in list';
+  ok '-pq'|'-qp' ~~ any(@$o), 'app -pq in list';
   ok '--notest' ~~ any(@$o), 'app -notest in list';
 
   $o = $c.refine-str( <app>, :filter, :str-mode(C-UNIX-OPTS-T2));
@@ -251,7 +251,7 @@ subtest {
   nok '--workdir=/tmp' ~~ any(@$o), 'app --workdir /tmp not in list';
   nok '-p' ~~ any(@$o), 'app -p not in list';
   nok '-q' ~~ any(@$o), 'app -q not in list';
-  ok '-pq' ~~ any(@$o), 'app -pq in list';
+  ok '-pq'|'-qp' ~~ any(@$o), 'app -pq in list';
 
   $o = $c.refine-str( <app p2>, :filter, :str-mode(C-UNIX-OPTS-T3));
 #say dump $o;

--- a/t/200-refine-json.t
+++ b/t/200-refine-json.t
@@ -235,7 +235,7 @@ subtest {
   nok '--workdir=/tmp' ~~ any(@$o), 'app --workdir /tmp not in list';
   nok '-p' ~~ any(@$o), 'app -p not in list';
   nok '-q' ~~ any(@$o), 'app -q not in list';
-  ok '-pq' ~~ any(@$o), 'app -pq in list';
+  ok '-pq'|'-qp' ~~ any(@$o), 'app -pq in list';
   ok '--notest' ~~ any(@$o), 'app -notest in list';
 
   $o = $c.refine-str( <app>, :filter, :str-mode(C-UNIX-OPTS-T2));
@@ -243,7 +243,7 @@ subtest {
   nok '--workdir=/tmp' ~~ any(@$o), 'app --workdir /tmp not in list';
   nok '-p' ~~ any(@$o), 'app -p not in list';
   nok '-q' ~~ any(@$o), 'app -q not in list';
-  ok '-pq' ~~ any(@$o), 'app -pq in list';
+  ok '-pq'|'-qp' ~~ any(@$o), 'app -pq in list';
 
   $o = $c.refine-str( <app p2>, :filter, :str-mode(C-UNIX-OPTS-T3));
 #say dump $o;


### PR DESCRIPTION
Hashes are unordered, so expecting a specific order in tests is
wrong. In the past Rakudo used to give out results in exactly the same
order every run (which is why these tests were working), but now it is
randomized due to security reasons.

Perhaps this module should sort the elements in refine-str, but that's
not for me to decide. For now, let's at least make these tests pass.