### PR TITLE
Fix wrong extension on provides field (META6.json)

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -8,7 +8,7 @@
   "tags": [ "config"],
 
   "provides": {
-    "Config::DataLang::Refine":     "lib/Config/DataLang/Refine.pm6"
+    "Config::DataLang::Refine":     "lib/Config/DataLang/Refine.rakumod"
   },
 
   "depends": [


### PR DESCRIPTION
I attempted to install this module but got the following error:
```
~ ❯❯❯ zef install Config::DataLang::Refine
===> Searching for: Config::DataLang::Refine
===> Searching for missing dependencies: Config::TOML
===> Searching for missing dependencies: Crane
===> Staging Crane:ver<0.1.1>
===> Staging [OK] for Crane:ver<0.1.1>
===> Staging Config::TOML:ver<0.1.2>
===> Staging [OK] for Config::TOML:ver<0.1.2>
===> Staging Config::DataLang::Refine:ver<0.7.5>:auth<cpan:MARTIMM>
Failed to open file /tmp/.zef/1707839948.24836/Config%3A%3ADataLang%3A%3ARefine%3Aver%3C0.7.5%3E%3Aauth%3Ccpan%3AMARTIMM%3E.tar.gz/config-datalang-refine-0.7.5/lib/Config/DataLang/Refine.pm6: No such file or directory
```
Seems like the extension wasn't updated on `META6.json`
Changing it to `.rakumod` so that the path is correct now fixed it :-)